### PR TITLE
 light-kafka version change with different version RecordProcessedResult

### DIFF
--- a/kafka/sidecar-backend/pom.xml
+++ b/kafka/sidecar-backend/pom.xml
@@ -11,7 +11,7 @@
         <java.version>11</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.main.class>com.networknt.server.Server</project.main.class>
-        <version.light-4j>2.0.30</version.light-4j>
+        <version.light-4j>2.0.31-SNAPSHOT</version.light-4j>
         <version.jackson>2.12.1</version.jackson>
         <version.slf4j>1.7.25</version.slf4j>
         <version.jose4j>0.6.3</version.jose4j>

--- a/kafka/sidecar-backend/src/main/java/com/networknt/mesh/kafka/backend/handler/KafkaRecordsPostHandler.java
+++ b/kafka/sidecar-backend/src/main/java/com/networknt/mesh/kafka/backend/handler/KafkaRecordsPostHandler.java
@@ -47,12 +47,12 @@ public class KafkaRecordsPostHandler implements LightHttpHandler {
                     StringWriter sw = new StringWriter();
                     PrintWriter pw = new PrintWriter(sw);
                     e.printStackTrace(pw);
-                    RecordProcessedResult rpr = new RecordProcessedResult(record, false, sw.toString());
+                    RecordProcessedResult rpr = new RecordProcessedResult(record, false, sw.toString(), null, null, record.getKey().toString());
                     results.add(rpr);
                 }
             } else {
                 // simulate processed successfully.
-                RecordProcessedResult rpr = new RecordProcessedResult(record, true, null);
+                RecordProcessedResult rpr = new RecordProcessedResult(record, true, null, null, null, null);
                 results.add(rpr);
             }
         }


### PR DESCRIPTION
Create the PR for to avoid local test object Deserializer error.
Should we wait until 2.0.release?